### PR TITLE
fix: add deprecated package to agent requirements

### DIFF
--- a/python/agents/travel-concierge/deployment/deploy.py
+++ b/python/agents/travel-concierge/deployment/deploy.py
@@ -68,6 +68,7 @@ def create(env_vars: dict[str, str]) -> None:
             "absl-py (>=2.2.1,<3.0.0)",
             "pydantic (>=2.10.6,<3.0.0)",
             "requests (>=2.32.3,<3.0.0)",
+            "deprecated (>=1.2.18,<2.0.0)",
         ],
         extra_packages=[
             "./travel_concierge",  # The main package


### PR DESCRIPTION
Fix agent deployment error in Vertex AI Agent Engine:

```
app.api.factory.utils.UserCodeControlPlaneError: Control plane operation failed due to user code: No module named 'deprecated'
```